### PR TITLE
Add Julia and  fix test.yml

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,6 +8,7 @@ on:
       - 'apt.txt'
       - 'conda-linux-64.lock'
       - 'environment.yml'
+      - 'Project.toml'
       - 'start'
       - 'postBuild'
       # Trigger rebuilds if the build process changes

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,7 @@ on:
       - 'apt.txt'
       - 'conda-linux-64.lock'
       - 'environment.yml'
+      - 'Project.toml'
       - 'postBuild'
       - 'start'
       # Trigger rebuilds if the test process changes

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,6 +35,8 @@ jobs:
       uses: jupyterhub/repo2docker-action@master
       with: # make sure username & password/token matches your registry
         NO_PUSH: "false"
+        DOCKER_USERNAME: ${{ secrets.QUAY_USERNAME }}
+        DOCKER_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
         DOCKER_REGISTRY: "quay.io"
         IMAGE_NAME: "nasasarp/python-image-tester"
         # Put repo contents in /srv/repo, so they aren't mangled when we put user home in /home/jovyan

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,7 +34,7 @@ jobs:
     - name: Build the image and push it if `NO_PUSH` disabled
       uses: jupyterhub/repo2docker-action@master
       with: # make sure username & password/token matches your registry
-        NO_PUSH: "true"
+        NO_PUSH: "false"
         DOCKER_REGISTRY: "quay.io"
         IMAGE_NAME: "nasasarp/python-image-tester"
         # Put repo contents in /srv/repo, so they aren't mangled when we put user home in /home/jovyan

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,1 @@
+# Existence of this file adds Julia to the environment

--- a/Project.toml
+++ b/Project.toml
@@ -1,1 +1,3 @@
 # Existence of this file adds Julia to the environment
+
+# test comment

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Build and push container image](https://github.com/NASA-SARP/hub-python-image/actions/workflows/build.yaml/badge.svg)](https://github.com/NASA-SARP/hub-python-image/actions/workflows/build.yaml)
 
 This JupyterHub docker image is built for the students of the NASA [Student Airborne Research Program (SARP)](https://science.nasa.gov/earth-science/early-career-opportunities/student-airborne-research-program/)
-and is hosted on https://quay.io/repository/nasasarp/hub-python-image. This image stands on the shoulders of the [Cryocloud base image](https://github.com/CryoInTheCloud/hub-image) and benefited greatly from the benefit of all the folks working on it.
+and is hosted on https://quay.io/repository/nasasarp/hub-python-image. This image stands on the shoulders of the [Cryocloud base image](https://github.com/CryoInTheCloud/hub-image) and benefited greatly from all the folks working on it.
 
 The image is built with [repo2docker](https://repo2docker.readthedocs.io), which uses Ubuntu Bionic Beaver (18.04) as the base image. 
 

--- a/postBuild
+++ b/postBuild
@@ -11,5 +11,4 @@ cp custom_jupyter_server_config.json ${NB_PYTHON_PREFIX}/etc/jupyter/jupyter_not
 # Install SpectralUnmixing Julia package
 wget https://github.com/emit-sds/SpectralUnmixing/archive/refs/tags/v0.2.3.zip -P /home/jovyan/
 unzip /home/jovyan/v0.2.3.zip -d /home/jovyan/
-# cd home/jovyan/SpectralUnmixing-0.2.3/ && julia -e 'using Pkg; Pkg.activate("."); Pkg.precompile()'
 rm /home/jovyan/v0.2.3.zip

--- a/postBuild
+++ b/postBuild
@@ -7,3 +7,9 @@ set -euo pipefail
 # used in the JupyterHub.
 cp custom_jupyter_server_config.json ${NB_PYTHON_PREFIX}/etc/jupyter/jupyter_server_config.d/
 cp custom_jupyter_server_config.json ${NB_PYTHON_PREFIX}/etc/jupyter/jupyter_notebook_config.d/
+
+# Install SpectralUnmixing Julia package
+wget https://github.com/emit-sds/SpectralUnmixing/archive/refs/tags/v0.2.3.zip -P /home/jovyan/
+unzip /home/jovyan/v0.2.3.zip -d /home/jovyan/
+# cd home/jovyan/SpectralUnmixing-0.2.3/ && julia -e 'using Pkg; Pkg.activate("."); Pkg.precompile()'
+rm /home/jovyan/v0.2.3.zip


### PR DESCRIPTION
## What has been built?

This PR adds the Julia programming language. It also adds the raw files for the [SpectralUnmixing package](https://github.com/emit-sds/SpectralUnmixing), although it doesn't include the precompile step required to run the package library.

This PR was also a test for the merge workflow, so it includes changes that complete the `test` github workflow.

## How was it done?
* `Project.toml` was added to the root directory. repo2docker includes Julia in the installation because this file exists
* CLI commands were added to the `postBuild` script for downloading and unzipping SpectralUnmixing

### Notes on SpectralUnmixing

One step required to run the SpectralUnmixing package is:
```bash
cd home/jovyan/SpectralUnmixing-0.2.3/ && julia -e 'using Pkg; Pkg.activate("."); Pkg.precompile()'
```
I originally included this in the `postBuild` script, but the precompile was not persistent when I opened the image in CryoCloud. The library runs fine if I run this line from Cryocloud after building the image. Perhaps the files that get created from the precompile step get removed between the creation of the container and loading in CryoCloud? Not clear. Revisit in a future effort if needed.

## How can it be tested?

Open the image in Cryocloud. A Julia icon should appear on the launcher. Also, running `julia` from the terminal should open the Julia REPL.

To use the spectral unmixing package run `cd home/jovyan/SpectralUnmixing-0.2.3/ && julia -e 'using Pkg; Pkg.activate("."); Pkg.precompile()'`. Run spectral unmixing with `julia --project unmix.jl ARGUMENTS`. See library readme for details.
